### PR TITLE
feat: Add two-layer authentication for Cloud Run backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,11 @@ coverage.xml
 .env.local
 .env.production
 
+# Service account keys (NEVER COMMIT)
+*-sa-key.json
+*-service-account.json
+credentials.json
+
 # Project specific
 *.ipynb
 *.md

--- a/root/.env.template
+++ b/root/.env.template
@@ -39,3 +39,15 @@ SENTENCE_TRANSFORMER_MODEL_NAME=all-MiniLM-L6-v2
 # Supabase
 SUPABASE_URL=https://your-project-ref.supabase.co
 SUPABASE_KEY=your-anon-key
+
+# Frontend Configuration
+# API base URL for the FastAPI backend
+# For local development: http://localhost:8000
+# For production (Cloud Run): https://your-service-url.a.run.app
+API_BASE_URL=http://localhost:8000
+
+# API Authentication (required for Cloud Run deployment)
+# API key for backend authentication (stored in GCP Secret Manager for production)
+QUIBO_API_KEY=your-api-key
+# Path to service account JSON file for Cloud Run IAM authentication
+GCP_SERVICE_ACCOUNT_FILE=path/to/frontend-sa-key.json

--- a/root/frontend/config.py
+++ b/root/frontend/config.py
@@ -1,9 +1,14 @@
+import os
 import streamlit as st
 from pathlib import Path
+from dotenv import load_dotenv
+
+# Load environment variables from parent directory (.env is in root/)
+ROOT_DIR = Path(__file__).parent.parent
+load_dotenv(ROOT_DIR / '.env')
 
 # Constants
-API_BASE_URL = "http://localhost:8000"  # FastAPI backend URL
-ROOT_DIR = Path(__file__).parent.parent
+API_BASE_URL = os.getenv('API_BASE_URL', 'http://localhost:8000')
 CACHE_DIR = ROOT_DIR / "data" / "cache"
 UPLOAD_DIRECTORY = ROOT_DIR / "data" / "uploads"
 

--- a/root/frontend/requirements.txt
+++ b/root/frontend/requirements.txt
@@ -3,3 +3,4 @@ python-dotenv>=0.19.0
 tenacity>=8.2.2
 nest-asyncio>=1.5.6 # Added to allow nested asyncio loops in Streamlit
 httpx>=0.25.0 # Added for making API calls from the frontend client
+google-auth>=2.0.0 # Added for Cloud Run authentication

--- a/root/frontend/services/project_service.py
+++ b/root/frontend/services/project_service.py
@@ -10,6 +10,13 @@ import re
 import uuid
 from typing import List, Dict, Any, Optional
 from pathlib import Path
+import sys
+
+# Add parent directories to path for imports
+sys.path.append(str(Path(__file__).parent.parent))
+
+from config import API_BASE_URL
+from utils.auth import get_auth_headers
 
 logger = logging.getLogger(__name__)
 
@@ -20,10 +27,14 @@ EXPORT_TIMEOUT = 60.0
 
 class ProjectService:
     """Service class for project-related API operations."""
-    
-    def __init__(self, base_url: str = "http://127.0.0.1:8000"):
+
+    def __init__(self, base_url: str = API_BASE_URL):
         """Initialize with API base URL."""
         self.base_url = base_url.rstrip('/')
+
+    def _get_headers(self) -> Dict[str, str]:
+        """Get authentication headers for API requests."""
+        return get_auth_headers(target_audience=self.base_url)
     
     def _validate_project_id(self, project_id: str) -> None:
         """
@@ -67,10 +78,12 @@ class ProjectService:
             List of project dictionaries with metadata and progress
         """
         try:
+            headers = self._get_headers()
             async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
                 response = await client.get(
                     f"{self.base_url}/projects",
-                    params={"archived": archived}
+                    params={"archived": archived},
+                    headers=headers
                 )
                 response.raise_for_status()
                 return response.json().get("projects", [])
@@ -96,10 +109,11 @@ class ProjectService:
             Project dictionary with full details
         """
         self._validate_project_id(project_id)
-        
+
         try:
+            headers = self._get_headers()
             async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
-                response = await client.get(f"{self.base_url}/project/{project_id}")
+                response = await client.get(f"{self.base_url}/project/{project_id}", headers=headers)
                 response.raise_for_status()
                 return response.json()
                 
@@ -126,8 +140,9 @@ class ProjectService:
         self._validate_project_id(project_id)
 
         try:
+            headers = self._get_headers()
             async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
-                response = await client.post(f"{self.base_url}/api/v2/projects/{project_id}/resume")
+                response = await client.post(f"{self.base_url}/api/v2/projects/{project_id}/resume", headers=headers)
                 response.raise_for_status()
                 return response.json()
                 
@@ -152,10 +167,11 @@ class ProjectService:
             Deletion confirmation
         """
         self._validate_project_id(project_id)
-        
+
         try:
+            headers = self._get_headers()
             async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
-                response = await client.delete(f"{self.base_url}/project/{project_id}/permanent")
+                response = await client.delete(f"{self.base_url}/project/{project_id}/permanent", headers=headers)
                 response.raise_for_status()
                 return response.json()
                 
@@ -181,12 +197,14 @@ class ProjectService:
             Archive operation confirmation
         """
         self._validate_project_id(project_id)
-        
+
         try:
+            headers = self._get_headers()
             async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
                 response = await client.post(
                     f"{self.base_url}/project/{project_id}/archive",
-                    json={"archived": archive}
+                    json={"archived": archive},
+                    headers=headers
                 )
                 response.raise_for_status()
                 return response.json()
@@ -214,12 +232,14 @@ class ProjectService:
         """
         self._validate_project_id(project_id)
         self._validate_export_format(format_type)
-        
+
         try:
+            headers = self._get_headers()
             async with httpx.AsyncClient(timeout=EXPORT_TIMEOUT) as client:
                 response = await client.get(
                     f"{self.base_url}/project/{project_id}/export",
-                    params={"format": format_type}
+                    params={"format": format_type},
+                    headers=headers
                 )
                 response.raise_for_status()
                 return response.content
@@ -245,10 +265,11 @@ class ProjectService:
             Progress data with completion percentages
         """
         self._validate_project_id(project_id)
-        
+
         try:
+            headers = self._get_headers()
             async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
-                response = await client.get(f"{self.base_url}/projects/{project_id}/progress")
+                response = await client.get(f"{self.base_url}/projects/{project_id}/progress", headers=headers)
                 response.raise_for_status()
                 return response.json()
                 
@@ -277,6 +298,7 @@ class ProjectService:
             Filtered list of projects
         """
         try:
+            headers = self._get_headers()
             async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
                 response = await client.get(
                     f"{self.base_url}/projects/search",
@@ -284,7 +306,8 @@ class ProjectService:
                         "query": query,
                         "status": status,
                         "sort_by": sort_by
-                    }
+                    },
+                    headers=headers
                 )
                 response.raise_for_status()
                 return response.json().get("projects", [])
@@ -310,10 +333,11 @@ class ProjectService:
             Job status data including content availability
         """
         self._validate_job_id(job_id)
-        
+
         try:
+            headers = self._get_headers()
             async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
-                response = await client.get(f"{self.base_url}/job_status/{job_id}")
+                response = await client.get(f"{self.base_url}/job_status/{job_id}", headers=headers)
                 response.raise_for_status()
                 return response.json()
                 

--- a/root/frontend/utils/auth.py
+++ b/root/frontend/utils/auth.py
@@ -1,0 +1,81 @@
+# ABOUTME: Authentication utility for Cloud Run backend access
+# ABOUTME: Generates auth headers with API key and GCP identity token
+
+import os
+import logging
+from pathlib import Path
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Root directory for resolving relative paths
+ROOT_DIR = Path(__file__).parent.parent.parent
+
+# Optional: Google Auth for Cloud Run IAM authentication
+try:
+    from google.auth.transport.requests import Request
+    from google.oauth2 import id_token
+    from google.oauth2.service_account import IDTokenCredentials
+    GOOGLE_AUTH_AVAILABLE = True
+except ImportError:
+    GOOGLE_AUTH_AVAILABLE = False
+    logger.info("google-auth not installed, using API key auth only")
+
+
+def get_auth_headers(target_audience: Optional[str] = None) -> Dict[str, str]:
+    """
+    Get authentication headers for Cloud Run requests.
+
+    This function provides two layers of authentication:
+    1. X-API-Key: Application-level API key validation
+    2. Authorization: GCP identity token for Cloud Run IAM (if service account configured)
+
+    Args:
+        target_audience: The Cloud Run service URL (used for identity token)
+
+    Returns:
+        Dictionary of headers to include in requests
+    """
+    headers = {}
+
+    # Layer 1: API Key (always added if configured)
+    api_key = os.getenv('QUIBO_API_KEY', '')
+    if api_key:
+        headers['X-API-Key'] = api_key
+
+    # Layer 2: GCP Identity Token (for Cloud Run IAM)
+    if GOOGLE_AUTH_AVAILABLE:
+        sa_file = os.getenv('GCP_SERVICE_ACCOUNT_FILE', '')
+        # Resolve relative paths against ROOT_DIR
+        if sa_file and not os.path.isabs(sa_file):
+            sa_file = str(ROOT_DIR / sa_file)
+        if sa_file and os.path.exists(sa_file) and target_audience:
+            try:
+                credentials = IDTokenCredentials.from_service_account_file(
+                    sa_file,
+                    target_audience=target_audience
+                )
+                request = Request()
+                credentials.refresh(request)
+                headers['Authorization'] = f'Bearer {credentials.token}'
+                logger.debug("Added GCP identity token to headers")
+            except Exception as e:
+                logger.warning(f"Failed to generate identity token: {e}")
+
+    return headers
+
+
+def is_auth_configured() -> bool:
+    """Check if authentication is properly configured."""
+    api_key = os.getenv('QUIBO_API_KEY', '')
+    sa_file = os.getenv('GCP_SERVICE_ACCOUNT_FILE', '')
+
+    if not api_key:
+        logger.warning("QUIBO_API_KEY not configured")
+        return False
+
+    if sa_file and not os.path.exists(sa_file):
+        logger.warning(f"Service account file not found: {sa_file}")
+        return False
+
+    return True


### PR DESCRIPTION
## Summary

- Add API key validation middleware to backend for application-level security
- Create auth utility module for frontend with GCP service account identity token generation
- Update all frontend API clients to include authentication headers
- Implement two-layer authentication flow: Cloud Run IAM + API Key validation

## Changes

### Backend
- Add `APIKeyAuthMiddleware` to `main.py` that validates `X-API-Key` header on all requests (except `/health`)

### Frontend
- Create `utils/auth.py` for generating auth headers (API key + GCP identity token)
- Update `api_client.py`, `services/project_service.py`, and `utils/api_client.py` with auth headers
- Fix dotenv loading to correctly resolve `.env` path from frontend directory
- Add `google-auth>=2.0.0` dependency for Cloud Run IAM authentication

### Configuration
- Update `.env.template` with auth configuration options
- Update `.gitignore` to exclude service account key files
- Document authentication setup in `docs/DEPLOYMENT.md`

## Authentication Flow

1. **Cloud Run IAM**: Service account-based identity token (satisfies org policy)
2. **API Key**: `X-API-Key` header validation in backend middleware

## Test plan

- [x] Backend deployed to Cloud Run with API key secret
- [x] Frontend connects to backend with proper authentication
- [x] All API endpoints return 200 OK with auth headers
- [x] Health check, models, personas, and projects endpoints verified